### PR TITLE
St72 integrate versioning in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: python:3.5
+image: python:3.5-slim
 
 # cache is used to specify a list of files and directories which should be cached between jobs. You can only use paths that are within the project workspace.
 # If cache is defined outside the scope of jobs, it means it is set globally and all jobs will use that definition
@@ -11,13 +11,13 @@ cache:
 # before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts. 
 # This can be an array or a multi-line string.
 before_script:
-  - python -V  # Print out python version for debugging
   - pip install pipenv
   - pipenv install
 
 stages:
   - test
   - deploy
+  - versioning
 
 # The YAML file defines a set of jobs with constraints stating when they should be run. 
 # You can specify an unlimited number of jobs which are defined as top-level elements with an arbitrary name and always have to contain at least the script clause.
@@ -33,7 +33,20 @@ test:
   artifacts:
     paths:
     - htmlcov
-     
+
+versioning:
+  stage: versioning
+  tags:
+    - docker-executor
+  script:
+    - pipenv graph >> pipenv_deps.txt
+    - dpkg -l >> system_deps.txt
+    - mv pipenv_deps.txt htmlcov
+    - mv system_deps.txt htmlcov
+  artifacts:
+    paths:
+      - htmlcov
+
 code_quality:
   tags:
     - docker-executor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,8 @@ stages:
 # It is also specified that only the master branch will be subject of this job. 
 test:
   stage: test
-  tags:
-   - docker-executor
+#  tags:
+#   - docker-executor
   script:
    - pipenv run python setup.py test
    - mkdir .public
@@ -79,8 +79,8 @@ code_analysis:
     
 pages:
   stage: deploy
-  tags:
-   - docker-executor
+#  tags:
+#   - docker-executor
   dependencies:
     - test
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,10 +28,12 @@ test:
    - docker-executor
   script:
    - pipenv run python setup.py test
-   - mv coverage.xml htmlcov
+   - mkdir .public
+   - cp coverage.xml .public/
+   - mv .public public
   artifacts:
     paths:
-    - htmlcov
+    - public
 
 dependency_check:
   stage: test
@@ -39,12 +41,14 @@ dependency_check:
     - pipenv graph >> pipenv_deps.txt
     - dpkg -l >> system_deps.txt
     - awk 'FNR>5 {print $2 ", " $3}' system_deps.txt >> system_deps.csv
-    - mv pipenv_deps.txt htmlcov
-    - mv system_deps.txt htmlcov
-    - mv system_deps.csv htmlcov
+    - mkdir .public
+    - cp pipenv_deps.txt .public/
+    - cp system_deps.txt .public/
+    - cp system_deps.csv .public/
+    - mv .public public
   artifacts:
     paths:
-      - htmlcov
+      - public
 
 code_quality:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ before_script:
 stages:
   - test
   - deploy
-  - versioning
 
 # The YAML file defines a set of jobs with constraints stating when they should be run. 
 # You can specify an unlimited number of jobs which are defined as top-level elements with an arbitrary name and always have to contain at least the script clause.
@@ -34,15 +33,15 @@ test:
     paths:
     - htmlcov
 
-versioning:
-  stage: versioning
-  tags:
-    - docker-executor
+dependency_check:
+  stage: test
   script:
     - pipenv graph >> pipenv_deps.txt
     - dpkg -l >> system_deps.txt
+    - awk 'FNR>5 {print $2 ", " $3}' system_deps.txt >> system_deps.csv
     - mv pipenv_deps.txt htmlcov
     - mv system_deps.txt htmlcov
+    - mv system_deps.csv htmlcov
   artifacts:
     paths:
       - htmlcov

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,12 +28,10 @@ test:
 #   - docker-executor
   script:
    - pipenv run python setup.py test
-   - mkdir .public
-   - cp coverage.xml .public/
-   - mv .public public
+   - cp coverage.xml htmlcov/
   artifacts:
     paths:
-    - public
+    - htmlcov
 
 dependency_check:
   stage: test


### PR DESCRIPTION
Created a step in CI in order to extract the pipenv and system libraries into `pipenv_deps.txt` and `system_deps.txt`.

Also, adopted the `python:3.5-slim` image since the `python:3.5` installs a lot of unneeded packages. This works fine with all the CI stages.

This started with a small tool I made for this particular purpose. Bacially it creates a docker container from scratch, installs the minimum needed packages and pipenv, clones the `ska-skeleton` and installs the pip packages. It then extracts all the information needed. The repo is in my personal account for now: https://github.com/jbmorgado/ska-python-skeleton-deps/tree/master